### PR TITLE
Added check for installed or default RCM domain name

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -50,6 +50,12 @@ class Module
     {
         $serviceManager = $event->getApplication()->getServiceManager();
 
+        $config = $serviceManager->get('config');
+
+        if (empty($config['Rcm']['installed']) && empty($config['Rcm']['defaultDomain'])) {
+            return;
+        }
+
         $request = $serviceManager->get('request');
 
         if ($request instanceof ConsoleRequest) {


### PR DESCRIPTION
This check is needed to keep RCM out of the way until the app is installed.  This is a temporary fix as I investigate better ways to accomplish this going forward.