### PR TITLE
Removed Unique key on already unique column

### DIFF
--- a/src/Entity/Country.php
+++ b/src/Entity/Country.php
@@ -49,7 +49,7 @@ class Country implements ApiInterface
      *
      * @link http://en.wikipedia.org/wiki/ISO_3166-1 ISO Standard
      *
-     * @ORM\Column(type="string", length=3, unique = true)
+     * @ORM\Column(type="string", length=3)
      * @ORM\Id
      */
     protected $iso3 = 'USA';


### PR DESCRIPTION
By using \Id for the $iso3 column you are already creating a unique index for this field.  Specifying it both as unique and as the Id causes non-keyed DB like Oracle to blow up on create and update.