### PR TITLE
Added new CMS Route in a BC way

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
     "bower-asset/rcm-loading": ">=0.1.12",
     "bower-asset/rcm-dialog": ">=0.1.1",
     "bower-asset/rcm-html-editor": ">=0.1.1",
-    "bower-asset/angular-translate":"2.7.2"
+    "bower-asset/angular-translate":"2.7.2",
+    "bower-asset/angular-utils-pagination": "^0.9.1"
   },
   "require-dev": {
     "phpunit/phpunit": "4.6.*",

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -445,7 +445,7 @@ return [
             'aliases' => [
                 'modules/rcm/' => __DIR__ . '/../public/',
                 // Global JS path for dependencies
-                'vendor/' => __DIR__ . '/../../vendor/bower-asset',
+                'vendor/' => __DIR__ . '/../../../bower-asset/',
             ],
             'collections' => [
                 /**

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -369,6 +369,13 @@ return [
             'rcmLogger' => 'Rcm\Service\Logger',
         ]
     ],
+
+    'route_manager' => [
+        'invokables' => [
+            'Rcm\Route\Cms' => 'Rcm\Route\Cms'
+        ],
+    ],
+
     'controllers' => [
         'abstract_factories' => [
             'Rcm\Factory\AbstractPluginControllerFactory'
@@ -385,8 +392,8 @@ return [
             'Rcm\Controller\CacheController' => '\Rcm\Controller\CacheController'
         ],
         'factories' => [
-            'Rcm\Controller\IndexController'
-            => 'Rcm\Factory\IndexControllerFactory',
+            'Rcm\Controller\IndexController' => 'Rcm\Factory\IndexControllerFactory',
+            'Rcm\Controller\CmsController' => 'Rcm\Factory\CmsControllerFactory',
         ],
     ],
     'view_helpers' => [

--- a/src/Acl/CmsPermissionChecks.php
+++ b/src/Acl/CmsPermissionChecks.php
@@ -64,14 +64,15 @@ class CmsPermissionChecks
             'Rcm\Acl\ResourceProvider'
         );
 
-        $path = '/' . $page->getName();
-        $siteLoginPage = $page->getSite()->getLoginPage();
-        $notAuthorizedPage = $page->getSite()->getNotAuthorizedPage();
-        $notFoundPage = $page->getSite()->getNotFoundPage();
+        /* ltrim added for BC */
+        $currentPage = $page->getName();
+        $siteLoginPage = ltrim($page->getSite()->getLoginPage(), '/');
+        $notAuthorizedPage = ltrim($page->getSite()->getNotAuthorizedPage(), '/');
+        $notFoundPage = ltrim($page->getSite()->getNotFoundPage(), '/');
 
-        if ($siteLoginPage == $path
-            || $notAuthorizedPage == $path
-            || $notFoundPage == $path
+        if ($siteLoginPage == $currentPage
+            || $notAuthorizedPage == $currentPage
+            || $notFoundPage == $currentPage
         ) {
             $allowed = true;
         }

--- a/src/Entity/PluginWrapper.php
+++ b/src/Entity/PluginWrapper.php
@@ -50,7 +50,7 @@ class PluginWrapper implements \JsonSerializable, \IteratorAggregate
     /**
      * @var integer Layout Placement.  This is used only for Page Containers.
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", nullable=true)
      */
     protected $layoutContainer = null;
 

--- a/src/Factory/CmsControllerFactory.php
+++ b/src/Factory/CmsControllerFactory.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Service Factory for the Index Controller
+ *
+ * This file contains the factory needed to generate an Index Controller.
+ *
+ * PHP version 5.3
+ *
+ * LICENSE: BSD
+ *
+ * @category  Reliv
+ * @package   Rcm
+ * @author    Westin Shafer <wshafer@relivinc.com>
+ * @copyright 2014 Reliv International
+ * @license   License.txt New BSD License
+ * @version   GIT: <git_id>
+ * @link      https://github.com/reliv
+ */
+namespace Rcm\Factory;
+
+use Rcm\Controller\CmsController;
+use Rcm\Controller\IndexController;
+use Zend\Di\ServiceLocator;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Service Factory for the Index Controller
+ *
+ * Factory for the Index Controller.
+ *
+ * @category  Reliv
+ * @package   Rcm
+ * @author    Westin Shafer <wshafer@relivinc.com>
+ * @copyright 2012 Reliv International
+ * @license   License.txt New BSD License
+ * @version   Release: 1.0
+ * @link      https://github.com/reliv
+ *
+ */
+class CmsControllerFactory implements FactoryInterface
+{
+
+    /**
+     * Create Service
+     *
+     * @param ServiceLocatorInterface $controllerManager Zend Controler Manager
+     *
+     * @return IndexController
+     */
+    public function createService(ServiceLocatorInterface $controllerManager)
+    {
+        /** @var \Zend\Mvc\Controller\ControllerManager $controllerMgr For IDE */
+        $controllerMgr = $controllerManager;
+
+        /** @var \Zend\ServiceManager\ServiceLocatorInterface $serviceLocator */
+        $serviceLocator = $controllerMgr->getServiceLocator();
+
+        /** @var \Rcm\Service\LayoutManager $layoutManager */
+        $layoutManager = $serviceLocator->get('Rcm\Service\LayoutManager');
+
+        /** @var \Rcm\Entity\Site $currentSite */
+        $currentSite = $serviceLocator->get('Rcm\Service\CurrentSite');
+
+        /** @var \Doctrine\ORM\EntityManagerInterface $entityManager */
+        $entityManager = $serviceLocator->get('Doctrine\ORM\EntityManager');
+
+        /** @var \Rcm\Repository\Page $pageRepo */
+        $pageRepo = $entityManager->getRepository('\Rcm\Entity\Page');
+
+        return new CmsController(
+            $layoutManager,
+            $currentSite,
+            $pageRepo
+        );
+    }
+}

--- a/src/Route/Cms.php
+++ b/src/Route/Cms.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * CMS Route
+ *
+ * This route will match CMS Urls to the DB pages in the CMS
+ *
+ * PHP version 5.5
+ *
+ * @category  Reliv
+ * @package   Rcm
+ * @author    Westin Shafer <shafer_w2002@yahoo.com>
+ * @copyright 2015 Reliv International
+ * @license   License.txt New BSD License
+ * @version   GIT: <git_id>
+ * @link      https://github.com/reliv
+ */
+
+namespace Rcm\Route;
+
+use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
+use Zend\Http\Request;
+use Zend\Mvc\Router\Http\RouteMatch;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Stdlib\RequestInterface;
+
+/**
+ * CMS Route
+ *
+ * This route will match CMS Urls to the DB pages in the CMS
+ *
+ * PHP version 5.5
+ *
+ * @category  Reliv
+ * @package   Rcm
+ * @author    Westin Shafer <shafer_w2002@yahoo.com>
+ * @copyright 2015 Reliv International
+ * @license   License.txt New BSD License
+ * @version   Release: <package_version>
+ * @link      https://github.com/reliv
+ */
+
+class Cms implements RcmRouteInterface, ServiceLocatorAwareInterface
+{
+    protected $controller = 'Rcm\Controller\CmsController';
+    protected $action = 'index';
+
+    protected $pageRepo;
+    protected $assembledParams = array();
+    protected $routePluginManager = null;
+    protected $options = array();
+
+    public function __construct($options)
+    {
+        $this->options = $options;
+    }
+
+
+    public function match(RequestInterface $request, $pathOffset = 0)
+    {
+        if (!$request instanceof Request) {
+            return null;
+        }
+
+        $pageUrl = substr($request->getUri()->getPath(), $pathOffset);
+
+        $type = $this->getPageType();
+
+        $pageParams = $this->parseUrl($pageUrl);
+
+        if (empty($pageParams)) {
+            return null;
+        }
+
+        try {
+            $page = $this->getPage($pageParams['pageName'], $type);
+        } catch (\Exception $e) {
+            return null;
+        }
+
+
+        if (empty($page)) {
+            return false;
+        }
+
+        $cms_params = array(
+            'page' => $page,
+            'controller' => $this->getController($type),
+            'action' => $this->getAction($type)
+        );
+
+        return new RouteMatch($cms_params, strlen($pageUrl));
+    }
+
+    protected function parseUrl($url)
+    {
+        $parsed = array(
+            'pageName' => 'index'
+        );
+
+        $options = $this->getOptions();
+        $path = str_replace($options['route'], '', $url);
+        $path = ltrim($path, '/');
+        $splitPath = explode('/', $path);
+
+        if (empty($splitPath[0])) {
+            return $parsed;
+        }
+
+        $pageName = $splitPath[0];
+        $revision = null;
+
+        if (!empty($splitPath[1])) {
+            $revision = $splitPath[1];
+        }
+
+        return array(
+            'pageName' => $pageName,
+            'revision' => $revision
+        );
+    }
+
+    protected function getController($type)
+    {
+        $options = $this->getOptions();
+
+        if (!empty($options['defaults']['controller'])) {
+            return $options['defaults']['controller'];
+        }
+
+        $config = $this->getServiceLocator()->get('config');
+
+        if (!empty($config['rcm']['pageTypes'][$type]['controller'])) {
+            return $config['rcm']['pageTypes'][$type]['controller'];
+        }
+
+        return $this->controller;
+    }
+
+    /**
+     * @param $pageName
+     * @param $type
+     * @return null|\Rcm\Entity\Page
+     */
+    protected function getPage($pageName, $type)
+    {
+        $serviceLocator = $this->getServiceLocator();
+
+        /** @var \Rcm\Entity\Site $currentSite */
+        $currentSite = $serviceLocator->get('Rcm\Service\CurrentSite');
+
+        if (!$currentSite->getSiteId()) {
+            return null;
+        }
+
+        /** @var \Doctrine\ORM\EntityManagerInterface $entityManager */
+        $entityManager = $serviceLocator->get('Doctrine\ORM\EntityManager');
+
+        /** @var \Rcm\Repository\Page $pageRepo */
+        $pageRepo = $entityManager->getRepository('\Rcm\Entity\Page');
+
+        /* Get the Page for display */
+        return $pageRepo->getPageByName(
+            $currentSite,
+            $pageName,
+            $type
+        );
+    }
+
+    protected function getAction($type)
+    {
+        $options = $this->getOptions();
+
+        if (!empty($options['defaults']['action'])) {
+            return $options['defaults']['action'];
+        }
+
+        $config = $this->getServiceLocator()->get('config');
+
+        if (!empty($config['rcm']['pageTypes'][$type]['action'])) {
+            return $config['rcm']['pageTypes'][$type]['action'];
+        }
+
+        return $this->action;
+    }
+
+    protected function getPageType()
+    {
+        $options = $this->getOptions();
+
+        if (!empty($options['type'])) {
+            return $options['type'];
+        } else {
+            return 'n';
+        }
+    }
+
+    public function assemble(array $params = array(), array $options = array())
+    {
+        $options = $this->getOptions();
+
+        $path = $options['route'];
+
+        if (!empty($params['page'])) {
+            $path = rtrim($path, '/').'/'.$params['page'];
+        }
+
+        if (!empty($params['revision'])) {
+            $path = rtrim($path, '/').'/'.$params['revision'];
+        }
+
+        return $path;
+    }
+
+    public function getAssembledParams()
+    {
+        return $this->assembledParams;
+    }
+
+    /**
+     * @param array $options
+     * @return static
+     */
+    public static function factory($options = array())
+    {
+        if ($options instanceof \Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        } elseif (!is_array($options)) {
+            throw new InvalidArgumentException(__METHOD__ . ' expects an array or Traversable set of options');
+        }
+
+        if (!isset($options['route'])) {
+            throw new \Rcm\Exception\InvalidArgumentException('Missing "route" in options array');
+        }
+
+        if (!isset($options['defaults'])) {
+            $options['defaults'] = array();
+        }
+
+        return new static($options);
+    }
+
+    /**
+     * Set service locator
+     *
+     * @param ServiceLocatorInterface $routePluginManager
+     */
+    public function setServiceLocator(ServiceLocatorInterface $routePluginManager)
+    {
+        $this->routePluginManager = $routePluginManager;
+    }
+
+    /**
+     * Get service locator
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator()
+    {
+        return $this->routePluginManager->getServiceLocator();
+    }
+
+    protected function getOptions()
+    {
+        return $this->options;
+    }
+}

--- a/src/Route/Cms.php
+++ b/src/Route/Cms.php
@@ -79,7 +79,6 @@ class Cms implements RcmRouteInterface, ServiceLocatorAwareInterface
             return null;
         }
 
-
         if (empty($page)) {
             return false;
         }
@@ -87,7 +86,8 @@ class Cms implements RcmRouteInterface, ServiceLocatorAwareInterface
         $cms_params = array(
             'page' => $page,
             'controller' => $this->getController($type),
-            'action' => $this->getAction($type)
+            'action' => $this->getAction($type),
+            'revision' => $pageParams['revision']
         );
 
         return new RouteMatch($cms_params, strlen($pageUrl));
@@ -96,11 +96,13 @@ class Cms implements RcmRouteInterface, ServiceLocatorAwareInterface
     protected function parseUrl($url)
     {
         $parsed = array(
-            'pageName' => 'index'
+            'pageName' => 'index',
+            'revision' => null
         );
 
         $options = $this->getOptions();
-        $path = str_replace($options['route'], '', $url);
+        $path = substr($url, strlen($options['route']));
+
         $path = ltrim($path, '/');
         $splitPath = explode('/', $path);
 

--- a/src/Route/RcmRouteInterface.php
+++ b/src/Route/RcmRouteInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Rcm Route Interface
+ *
+ * This interface is used to identify RCM/CMS routes from normal Zend Routes.  This allows the
+ * CMS to stay out of the way and not break existing applications.
+ *
+ * PHP version 5.5
+ *
+ * @category  Reliv
+ * @package   Rcm
+ * @author    Westin Shafer <shafer_w2002@yahoo.com>
+ * @copyright 2015 Reliv International
+ * @license   License.txt New BSD License
+ * @version   GIT: <git_id>
+ * @link      https://github.com/reliv
+ */
+namespace Rcm\Route;
+
+use Zend\Mvc\Router\Http\RouteInterface;
+
+/**
+ * Rcm Route Interface
+ *
+ * This interface is used to identify RCM/CMS routes from normal Zend Routes.  This allows the
+ * CMS to stay out of the way and not break existing applications.
+ *
+ * PHP version 5.5
+ *
+ * @category  Reliv
+ * @package   Rcm
+ * @author    Westin Shafer <shafer_w2002@yahoo.com>
+ * @copyright 2015 Reliv International
+ * @license   License.txt New BSD License
+ * @version   Release: <package_version>
+ * @link      https://github.com/reliv
+ */
+interface RcmRouteInterface extends RouteInterface
+{
+
+}

--- a/test/Rcm/src/Controller/CmsControllerTest.php
+++ b/test/Rcm/src/Controller/CmsControllerTest.php
@@ -1,0 +1,609 @@
+<?php
+/**
+ * Unit Test for the IndexController
+ *
+ * This file contains the unit test for the IndexController
+ *
+ * PHP version 5.3
+ *
+ * LICENSE: BSD
+ *
+ * @category  Reliv
+ * @package   Rcm
+ * @author    Westin Shafer <wshafer@relivinc.com>
+ * @copyright 2014 Reliv International
+ * @license   License.txt New BSD License
+ * @version   GIT: <git_id>
+ * @link      http://github.com/reliv
+ */
+namespace RcmTest\Controller;
+
+require_once __DIR__ . '/../../../autoload.php';
+
+use Rcm\Controller\CmsController;
+use Rcm\Entity\Country;
+use Rcm\Entity\Domain;
+use Rcm\Entity\Language;
+use Rcm\Entity\Page;
+use Rcm\Entity\Revision;
+use Rcm\Entity\Site;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\Http\TreeRouteStack as HttpRouter;
+use Zend\Mvc\Router\RouteMatch;
+
+/**
+ * Unit Test for the IndexController
+ *
+ * Unit Test for the IndexController
+ *
+ * @category  Reliv
+ * @package   Rcm
+ * @author    Westin Shafer <wshafer@relivinc.com>
+ * @copyright 2012 Reliv International
+ * @license   License.txt New BSD License
+ * @version   Release: 1.0
+ * @link      http://github.com/reliv
+ */
+class CmsControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Rcm\Controller\CmsController */
+    protected $controller;
+
+    /** @var \Zend\Http\Request */
+    protected $request;
+
+    /** @var \Zend\Http\Response */
+    protected $response;
+
+    /** @var \Zend\Mvc\Router\RouteMatch */
+    protected $routeMatch;
+
+    /** @var \Zend\Mvc\MvcEvent */
+    protected $event;
+
+    protected $pageData;
+
+    protected $skipCounter = 0;
+
+    protected $layoutOverride;
+
+    /** @var \Rcm\Entity\Site */
+    protected $currentSite;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    protected $mockUserServicePlugin;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    protected $mockIsPageAllowed;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    protected $mockShouldShowRevisions;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    protected $mockRedirectToPage;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    protected $mockIsSiteAdmin;
+
+    /** @var  \Rcm\Repository\Page */
+    protected $mockPageRepo;
+
+    /**
+     * Setup for tests
+     *
+     * @return null
+     */
+    public function setUp()
+    {
+
+        $this->mockPageRepo = $this
+            ->getMockBuilder('\Rcm\Repository\Page')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockPageRepo->expects($this->any())
+            ->method('getPageByName')
+            ->will(
+                $this->returnCallback([$this, 'pageRepoMockCallback'])
+            );
+
+        $mockLayoutManager = $this
+            ->getMockBuilder('\Rcm\Service\LayoutManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockLayoutManager->expects($this->any())
+            ->method('getSiteLayout')
+            ->will(
+                $this->returnCallback([$this, 'layoutManagerMockCallback'])
+            );
+
+        $this->mockUserServicePlugin = $this
+            ->getMockBuilder('\Rcm\Controller\Plugin\RcmIsAllowed')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockIsPageAllowed = $this
+            ->getMockBuilder('\Rcm\Controller\Plugin\RcmIsPageAllowed')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockShouldShowRevisions = $this
+            ->getMockBuilder('\Rcm\Controller\Plugin\ShouldShowRevisions')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockRedirectToPage = $this
+            ->getMockBuilder('\Rcm\Controller\Plugin\RedirectToPage')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockIsSiteAdmin = $this
+            ->getMockBuilder('\Rcm\Controller\Plugin\IsSiteAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->currentSite = new Site();
+        $this->currentSite->setSiteId(1);
+        $this->currentSite->setNotFoundPage('not-found');
+
+
+        $config = [
+            'contentManager' => [
+                'type' => 'Zend\Mvc\Router\Http\Segment',
+                'options' => [
+                    'route' => '/rcm[/:page][/:revision]',
+                    'defaults' => [
+                        'controller' => 'Rcm\Controller\IndexController',
+                        'action' => 'index',
+                    ]
+                ],
+            ],
+            'contentManagerWithPageType' => [
+                'type' => 'Zend\Mvc\Router\Http\Segment',
+                'options' => [
+                    'route' => '/rcm/:pageType/:page[/:revision]',
+                    'constraints' => [
+                        'pageType' => '[a-z]',
+                    ],
+                    'defaults' => [
+                        'controller' => 'Rcm\Controller\IndexController',
+                        'action' => 'index',
+                    ]
+                ],
+            ],
+        ];
+
+        /** @var \Rcm\Service\LayoutManager $mockLayoutManager */
+        $this->controller = new CmsController(
+            $mockLayoutManager,
+            $this->currentSite,
+            $this->mockPageRepo
+        );
+
+        $this->controller->getPluginManager()
+            ->setService('rcmIsAllowed', $this->mockUserServicePlugin)
+            ->setService('shouldShowRevisions', $this->mockShouldShowRevisions)
+            ->setService('redirectToPage', $this->mockRedirectToPage)
+            ->setService('rcmIsSiteAdmin', $this->mockIsSiteAdmin)
+            ->setService('rcmIsPageAllowed', $this->mockIsPageAllowed);
+
+        $this->request = new Request();
+        $this->routeMatch = new RouteMatch(['controller' => 'index']);
+        $this->event = new MvcEvent();
+        $routerConfig = $config;
+        $router = HttpRouter::factory($routerConfig);
+
+        $this->event->setRouter($router);
+        $this->event->setRouteMatch($this->routeMatch);
+        $this->controller->setEvent($this->event);
+    }
+
+    /**
+     * Test the constructor is working
+     *
+     * @return void
+     * @covers Rcm\Controller\IndexController
+     */
+    public function testConstructor()
+    {
+        /** @var \Rcm\Repository\Page $mockPageRepo */
+        $mockPageRepo = $this
+            ->getMockBuilder('\Rcm\Repository\Page')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var \Rcm\Service\LayoutManager $mockLayoutManager */
+        $mockLayoutManager = $this
+            ->getMockBuilder('\Rcm\Service\LayoutManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $currentSite = new Site();
+        $currentSite->setSiteId(1);
+
+        $controller = new IndexController(
+            $mockLayoutManager,
+            $currentSite,
+            $mockPageRepo
+        );
+
+        $this->assertTrue($controller instanceof IndexController);
+    }
+
+    /**
+     * Test the index controller for normal functionality
+     *
+     * @return null
+     * @covers Rcm\Controller\IndexController
+     */
+    public function testIndexAction()
+    {
+        $this->pageData = $this->getPageData(42, 'my-test', 443, 'z');
+
+        $mockPage = $this->getMockBuilder('\Rcm\Entity\Page')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockPage->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('my-test'));
+
+        $mockPage->expects($this->any())
+            ->method('getPageType')
+            ->will($this->returnValue('z'));
+
+        $mockRevision = $this->getMockBuilder('\Rcm\Entity\Revision')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockRevision->expects($this->any())
+            ->method('')
+            ->will($this->returnValue(443));
+
+        $mockPage->expects($this->any())
+            ->method('getRevisionById')
+            ->will($this->returnValue($mockRevision));
+
+        $mockPage->expects($this->any())
+            ->method('getCurrentRevision')
+            ->will($this->returnValue($mockRevision));
+
+
+
+
+
+        $this->routeMatch->setParam('action', 'index');
+        $this->routeMatch->setParam('page', $mockPage);
+        $this->routeMatch->setParam('revision', 443);
+
+        $this->mockUserServicePlugin->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $this->mockIsPageAllowed->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $this->mockShouldShowRevisions->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $this->mockIsPageAllowed->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $this->controller->dispatch($this->request);
+
+        /** @var \Zend\Http\Response $response */
+        $response = $this->controller->getResponse();
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Test the index controller attempts to fetch the index or home page with
+     * revision but user is not allowed to see revisions
+     *
+     * @return null
+     * @covers Rcm\Controller\IndexController
+     */
+    public function testIndexActionHomePageRedirectWhenUserNotAllowedForRevisions(
+    )
+    {
+        $mockPage = $this->getMockBuilder('\Rcm\Entity\Page')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockPage->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('my-test'));
+
+        $mockPage->expects($this->any())
+            ->method('getPageType')
+            ->will($this->returnValue('z'));
+
+        $mockRevision = $this->getMockBuilder('\Rcm\Entity\Revision')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockRevision->expects($this->any())
+            ->method('')
+            ->will($this->returnValue(443));
+
+        $mockPage->expects($this->any())
+            ->method('getRevisionById')
+            ->will($this->returnValue($mockRevision));
+
+        $mockPage->expects($this->any())
+            ->method('getCurrentRevision')
+            ->will($this->returnValue($mockRevision));
+
+        $this->pageData = $this->getPageData(42, 'my-test', 443, 'z');
+
+
+
+        $this->routeMatch->setParam('action', 'index');
+        $this->routeMatch->setParam('page', $mockPage);
+
+        $response = $this->controller->getResponse();
+        $response->getHeaders()->addHeaderLine('Location', '/my-test');
+        $response->setStatusCode(302);
+
+        $this->mockIsPageAllowed->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $mockRedirectToPage = $this
+            ->getMockBuilder('\Rcm\Controller\Plugin\RedirectToPage')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockRedirectToPage->expects($this->any())
+            ->method('__invoke')
+            ->with(
+                $this->equalTo('my-test'),
+                $this->equalTo('z')
+            )
+            ->will($this->returnValue($response));
+
+        $this->controller->getPluginManager()
+            ->setService('redirectToPage', $mockRedirectToPage);
+
+        $result = $this->controller->dispatch($this->request);
+
+        // Assertions needed
+    }
+
+    /**
+     * Test the index controller attempts to fetch the index or home page
+     *
+     * @return null
+     * @covers Rcm\Controller\IndexController
+     */
+    public function testIndexActionPageNotFoundWithCmsPageNotFoundAvailable()
+    {
+
+        $mockPage = $this->getMockBuilder('\Rcm\Entity\Page')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockPage->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('my-test'));
+
+        $mockPage->expects($this->any())
+            ->method('getPageType')
+            ->will($this->returnValue('z'));
+
+        $mockRevision = $this->getMockBuilder('\Rcm\Entity\Revision')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockRevision->expects($this->any())
+            ->method('')
+            ->will($this->returnValue(443));
+
+        $mockPage->expects($this->any())
+            ->method('getRevisionById')
+            ->will($this->returnValue($mockRevision));
+
+        $mockPage->expects($this->any())
+            ->method('getCurrentRevision')
+            ->will($this->returnValue($mockRevision));
+
+        $this->skipCounter = 1;
+        $this->pageData = $this->getPageData(3, 'not-found', 22, 'n');
+
+        $this->routeMatch->setParam('action', 'index');
+        $this->routeMatch->setParam('page', $mockPage);
+
+        $this->mockUserServicePlugin->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $this->mockShouldShowRevisions->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $this->mockIsPageAllowed->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $result = $this->controller->dispatch($this->request);
+
+        /** @var \Zend\Http\Response $response */
+        $response = $this->controller->getResponse();
+
+    }
+
+    /**
+     * Test the index controller with Layout Template override
+     *
+     * @return null
+     * @covers Rcm\Controller\IndexController
+     */
+    public function testIndexActionWithLayoutOverride()
+    {
+
+        $mockPage = $this->getMockBuilder('\Rcm\Entity\Page')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockPage->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('my-test'));
+
+        $mockPage->expects($this->any())
+            ->method('getPageType')
+            ->will($this->returnValue('z'));
+
+        $mockRevision = $this->getMockBuilder('\Rcm\Entity\Revision')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockRevision->expects($this->any())
+            ->method('')
+            ->will($this->returnValue(443));
+
+        $mockPage->expects($this->any())
+            ->method('getRevisionById')
+            ->will($this->returnValue($mockRevision));
+
+        $mockPage->expects($this->any())
+            ->method('getCurrentRevision')
+            ->will($this->returnValue($mockRevision));
+
+        $mockPage->expects($this->any())
+            ->method('getSiteLayoutOverride')
+            ->will($this->returnValue('newLayout'));
+
+        $this->layoutOverride = 'newLayout';
+
+
+        $this->routeMatch->setParam('action', 'index');
+        $this->routeMatch->setParam('page', $mockPage);
+
+        $this->mockUserServicePlugin->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $this->mockShouldShowRevisions->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $this->mockIsPageAllowed->expects($this->any())
+            ->method('__invoke')
+            ->will($this->returnValue(true));
+
+        $result = $this->controller->dispatch($this->request);
+
+        /** @var \Zend\Http\Response $response */
+        $response = $this->controller->getResponse();
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertEquals(
+            'layout/' . $this->layoutOverride,
+            $this->controller->layout()->getTemplate()
+        );
+    }
+
+    /**
+     * Callback for Page Manager mock
+     *
+     * @return mixed
+     * @throws \Rcm\Exception\ContainerNotFoundException
+     */
+    public function pageRepoMockCallback()
+    {
+        if ($this->skipCounter > 0) {
+            $this->skipCounter--;
+            return null;
+        }
+
+        return $this->pageData;
+    }
+
+    /**
+     * Callback for layout Manager mock
+     *
+     * @return mixed
+     * @throws \Rcm\Exception\PageNotFoundException
+     */
+    public function layoutManagerMockCallback()
+    {
+        return $this->layoutOverride;
+    }
+
+    /**
+     * Get Test Page Data for Page Repo Mocks
+     *
+     * @param integer $pageId             PageID
+     * @param integer $pageName           PageName
+     * @param integer $revisionId         RevisionId
+     * @param string  $pageType           PageType
+     * @param boolean $useStaged          Use staged revision instead of published
+     * @param string  $siteLayoutOverride Layout Override
+     *
+     * @return array
+     */
+    protected function getPageData(
+        $pageId,
+        $pageName,
+        $revisionId,
+        $pageType = 'n',
+        $useStaged = false,
+        $siteLayoutOverride = null
+    ) {
+        $country = new Country();
+        $country->setCountryName('United States');
+        $country->setIso2('US');
+        $country->setIso3('USA');
+
+        $language = new Language();
+        $language->setLanguageId(1);
+        $language->setIso6391('en');
+        $language->setIso6392b('eng');
+        $language->setIso6392t('eng');
+
+        $domain = new Domain();
+        $domain->setDomainId(1);
+        $domain->setDomainName('reliv.com');
+
+        $site = new Site();
+        $site->setSiteId(1);
+        $site->setCountry($country);
+        $site->setLanguage($language);
+        $site->setLoginPage('login');
+        $site->setNotFoundPage('not-found');
+        $site->setDomain($domain);
+
+        $revision = new Revision();
+        $revision->setRevisionId($revisionId);
+        $revision->setAuthor('Westin Shafer');
+        $revision->setCreatedDate(new \DateTime());
+        $revision->setPublishedDate(new \DateTime());
+
+
+        $page = new Page();
+        $page->setSite($site);
+        $page->setName($pageName);
+        $page->setPageId($pageId);
+        $page->setPageType($pageType);
+        $page->addRevision($revision);
+        $page->setPublishedRevision($revision);
+
+        if ($useStaged) {
+            $page->setStagedRevision($revision);
+        }
+
+        $page->setPageId(22);
+        $page->setSiteLayoutOverride($siteLayoutOverride);
+
+
+        return $page;
+    }
+}


### PR DESCRIPTION
This PR adds a CMS route to Rcm.

CMS routes should now be configured as such:

```php
return array(
    'router' => array(
        'routes' => array(
            'type' => 'Rcm\Route\Cms',
            'options' => array(
                'route'  => '/some-route',
                'type' => 'n' #optional.  Defaults to 'n' if left blank
                'defaults' => array(
                    'controller' => 'some-controler',  #optional. Defaults to Rcm\Controller\CmsController if blank
                    'action' => 'some-action', #optional. Defaults to indexAction if blank
                ),
            ),
        ),
    ),
)
```

Possible BC breaks:
   The route-match now returns the Page object instead of the page name.   This was done to reduce a couple of query calls for the same object.  Any controller that extends the index controller should pay attention to this change.